### PR TITLE
透過PNG関連エンティティの追加

### DIFF
--- a/lib/domain/entities/transparent_png.dart
+++ b/lib/domain/entities/transparent_png.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'photo.dart';
+
+class TransparentPng {
+  final String id;
+  final String path;
+  final Uint8List data;
+  final Size size;
+  final PhotoMetadata metadata;
+  
+  TransparentPng({
+    required this.id,
+    required this.path,
+    required this.data,
+    required this.size,
+    required this.metadata,
+  });
+  
+  factory TransparentPng.fromPhoto(Photo photo, Uint8List data, Size size) {
+    return TransparentPng(
+      id: photo.id,
+      path: photo.path,
+      data: data,
+      size: size,
+      metadata: photo.metadata,
+    );
+  }
+  
+  TransparentPng copyWith({
+    String? id,
+    String? path,
+    Uint8List? data,
+    Size? size,
+    PhotoMetadata? metadata,
+  }) {
+    return TransparentPng(
+      id: id ?? this.id,
+      path: path ?? this.path,
+      data: data ?? this.data,
+      size: size ?? this.size,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+}
+
+class TransparentPngCreationResult {
+  final TransparentPng transparentPng;
+  final String savedPath;
+  final bool addedToOverlays;
+
+  TransparentPngCreationResult({
+    required this.transparentPng,
+    required this.savedPath,
+    required this.addedToOverlays,
+  });
+}
+
+class TransparentPngSettings {
+  final int threshold;
+  final bool applyNoiseFilter;
+  final bool autoTrim;
+  final int padding;
+  
+  const TransparentPngSettings({
+    this.threshold = 30,
+    this.applyNoiseFilter = true,
+    this.autoTrim = true,
+    this.padding = 10,
+  });
+  
+  TransparentPngSettings copyWith({
+    int? threshold,
+    bool? applyNoiseFilter,
+    bool? autoTrim,
+    int? padding,
+  }) {
+    return TransparentPngSettings(
+      threshold: threshold ?? this.threshold,
+      applyNoiseFilter: applyNoiseFilter ?? this.applyNoiseFilter,
+      autoTrim: autoTrim ?? this.autoTrim,
+      padding: padding ?? this.padding,
+    );
+  }
+}


### PR DESCRIPTION
# 透過PNG関連エンティティの追加

## 概要
設計ドキュメント（eidas/photo-app/design-docs）に基づいて、透過PNG関連のエンティティを追加しました。

## 変更内容
- `lib/domain/entities/transparent_png.dart`ファイルを追加
  - `TransparentPng`クラス: 透過PNG画像データを表現するエンティティ
  - `TransparentPngCreationResult`クラス: 透過PNG作成結果を表現するエンティティ
  - `TransparentPngSettings`クラス: 透過PNG作成時の設定を表現するエンティティ

## 修正・変更しなかった事項
- 既存のエンティティ（`Photo`や`OverlayImage`）は修正していません
- 透過PNG作成ロジックの実装はこのPRには含まれていません（データ層・ユースケース層で実装予定）

## 確認事項
- Flutter 3のnull safetyに対応しています
- 詳細設計に基づいて実装しています

## 関連資料
- [detailed-design.md](https://github.com/eidas/photo-app/blob/main/design-docs/detailed-design.md)
- [updated-design-flutter3.md](https://github.com/eidas/photo-app/blob/main/design-docs/updated-design-flutter3.md)