### PR TITLE
ドメイン層のユースケース実装

### DIFF
--- a/lib/domain/usecases/create_transparent_png.dart
+++ b/lib/domain/usecases/create_transparent_png.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../entities/transparent_png.dart';
+import '../repositories/transparent_png_repository.dart';
+
+/// 透過PNG作成に関するユースケース
+class CreateTransparentPngUseCase {
+  final TransparentPngRepository transparentPngRepository;
+
+  CreateTransparentPngUseCase({
+    required this.transparentPngRepository,
+  });
+
+  /// 2枚の画像から透過PNGを作成する
+  /// 
+  /// [image1]と[image2]の差分を抽出して透過PNGを生成します
+  /// [threshold]は差分検出の閾値（デフォルト: 30）
+  Future<TransparentPng> createFromImages(File image1, File image2, {int threshold = 30}) async {
+    // 透過PNG生成
+    final transparentPng = await transparentPngRepository.createTransparentPng(
+      image1, 
+      image2,
+      threshold: threshold,
+    );
+    
+    return transparentPng;
+  }
+
+  /// 画像から透過PNGを作成して保存する
+  /// 
+  /// 生成した透過PNGを保存し、オーバーレイとして使用可能にします
+  Future<String> saveTransparentPng(Uint8List pngData) async {
+    return await transparentPngRepository.saveTransparentPng(pngData);
+  }
+  
+  /// デバイスのギャラリーから画像を選択する
+  Future<File?> pickImage() async {
+    return await transparentPngRepository.pickImage();
+  }
+  
+  /// 透過PNGのプレビューを生成する
+  ///
+  /// 2枚の画像から透過PNGのプレビューを生成します。
+  /// 実際の保存は行いません。
+  Future<Uint8List> previewTransparentPng(File image1, File image2, {int threshold = 30}) async {
+    return await transparentPngRepository.previewTransparentPng(image1, image2, threshold: threshold);
+  }
+}
+
+/// CreateTransparentPngUseCase用のプロバイダー
+final createTransparentPngUseCaseProvider = Provider<CreateTransparentPngUseCase>((ref) {
+  final transparentPngRepository = ref.watch(transparentPngRepositoryProvider);
+  
+  return CreateTransparentPngUseCase(
+    transparentPngRepository: transparentPngRepository,
+  );
+});

--- a/lib/domain/usecases/index.dart
+++ b/lib/domain/usecases/index.dart
@@ -1,0 +1,3 @@
+export 'take_photo.dart';
+export 'create_transparent_png.dart';
+export 'manage_overlay.dart';

--- a/lib/domain/usecases/manage_overlay.dart
+++ b/lib/domain/usecases/manage_overlay.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+import 'dart:ui';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../entities/overlay_image.dart';
+import '../repositories/overlay_repository.dart';
+
+/// オーバーレイ操作に関するユースケース
+class ManageOverlayUseCase {
+  final OverlayRepository overlayRepository;
+  
+  ManageOverlayUseCase({
+    required this.overlayRepository,
+  });
+  
+  /// 現在のオーバーレイのリストを取得する
+  List<OverlayImage> getOverlays() {
+    return overlayRepository.getOverlays();
+  }
+  
+  /// 指定されたパスの画像をオーバーレイとして追加する
+  Future<OverlayImage> addOverlay(String path) async {
+    return await overlayRepository.addOverlay(path);
+  }
+  
+  /// 指定されたIDのオーバーレイを削除する
+  void removeOverlay(String id) {
+    overlayRepository.removeOverlay(id);
+  }
+  
+  /// オーバーレイの位置とサイズを更新する
+  void updateOverlay(
+    String id, {
+    double? x,
+    double? y,
+    double? scale,
+    double? rotation,
+  }) {
+    overlayRepository.updateOverlay(
+      id,
+      x: x,
+      y: y,
+      scale: scale,
+      rotation: rotation,
+    );
+  }
+  
+  /// 全てのオーバーレイをクリアする
+  void clearOverlays() {
+    overlayRepository.clearOverlays();
+  }
+  
+  /// オーバーレイを指定位置にリセットする
+  void resetOverlayPosition(String id, {required Size viewSize}) {
+    // 画面の中央に配置
+    final x = viewSize.width / 2;
+    final y = viewSize.height / 2;
+    
+    overlayRepository.updateOverlay(
+      id,
+      x: x,
+      y: y,
+      scale: 1.0,
+      rotation: 0.0,
+    );
+  }
+  
+  /// オーバーレイのファイルを別の形式（PNG/JPEG）に変換する
+  Future<File> convertOverlayFormat(String id, String format) async {
+    if (format != 'png' && format != 'jpeg') {
+      throw ArgumentError('Format must be either "png" or "jpeg"');
+    }
+    
+    return await overlayRepository.convertOverlayFormat(id, format);
+  }
+  
+  /// オーバーレイの透明度を調整する（PNG形式のみ）
+  Future<OverlayImage> adjustOverlayTransparency(String id, double opacity) async {
+    if (opacity < 0.0 || opacity > 1.0) {
+      throw ArgumentError('Opacity must be between 0.0 and 1.0');
+    }
+    
+    return await overlayRepository.adjustOverlayTransparency(id, opacity);
+  }
+  
+  /// デバイスのギャラリーから画像をオーバーレイとして読み込む
+  Future<OverlayImage?> importOverlayFromGallery() async {
+    return await overlayRepository.importFromGallery();
+  }
+}
+
+/// ManageOverlayUseCase用のプロバイダー
+final manageOverlayUseCaseProvider = Provider<ManageOverlayUseCase>((ref) {
+  final overlayRepository = ref.watch(overlayRepositoryProvider);
+  
+  return ManageOverlayUseCase(
+    overlayRepository: overlayRepository,
+  );
+});

--- a/lib/domain/usecases/take_photo.dart
+++ b/lib/domain/usecases/take_photo.dart
@@ -1,0 +1,51 @@
+import 'dart:ui';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../entities/photo.dart';
+import '../entities/overlay_image.dart';
+import '../repositories/photo_repository.dart';
+import '../repositories/camera_repository.dart';
+
+/// 写真撮影に関するユースケース
+class TakePhotoUseCase {
+  final PhotoRepository photoRepository;
+  final CameraRepository cameraRepository;
+
+  TakePhotoUseCase({
+    required this.photoRepository,
+    required this.cameraRepository,
+  });
+
+  /// 通常の写真を撮影する
+  Future<Photo> takePhoto() async {
+    // カメラが初期化されていなければ初期化
+    if (!await cameraRepository.isInitialized()) {
+      await cameraRepository.initialize();
+    }
+    
+    // 写真を撮影して返す
+    return await photoRepository.takePhoto();
+  }
+
+  /// オーバーレイ付きの写真を撮影する
+  Future<Photo> takeOverlayPhoto(List<OverlayImage> overlays, Size viewSize) async {
+    // カメラが初期化されていなければ初期化
+    if (!await cameraRepository.isInitialized()) {
+      await cameraRepository.initialize();
+    }
+    
+    // オーバーレイ付きの写真を撮影して返す
+    return await photoRepository.takeOverlayPhoto(overlays, viewSize);
+  }
+}
+
+/// TakePhotoUseCase用のプロバイダー
+final takePhotoUseCaseProvider = Provider<TakePhotoUseCase>((ref) {
+  final photoRepository = ref.watch(photoRepositoryProvider);
+  final cameraRepository = ref.watch(cameraRepositoryProvider);
+  
+  return TakePhotoUseCase(
+    photoRepository: photoRepository,
+    cameraRepository: cameraRepository,
+  );
+});


### PR DESCRIPTION
## 概要
設計ドキュメント(eidas/photo-app/design-docs)に基づいて、domain/usecases ディレクトリとユースケースクラスを実装しました。

## 追加した機能
- `TakePhotoUseCase`: 写真撮影に関するユースケース
  - 通常の写真撮影
  - オーバーレイ付き写真撮影
- `CreateTransparentPngUseCase`: 透過PNG作成に関するユースケース
  - 2枚の画像から透過PNG作成
  - 透過PNG保存
  - 画像選択
  - プレビュー生成
- `ManageOverlayUseCase`: オーバーレイ操作に関するユースケース
  - オーバーレイ追加/削除/更新
  - オーバーレイ位置リセット
  - フォーマット変換
  - 透明度調整
  - ギャラリーからインポート

## 動作確認
- 既存のリポジトリインターフェースと適合するよう設計しました
- 依存性の注入のためのRiverpodプロバイダーを各ユースケースに実装しました

既存のコードは修正せず、新規ファイルのみ追加しています。