### PR TITLE
Add missing providers for camera, overlay, and transparent PNG

### DIFF
--- a/lib/presentation/providers/camera_provider.dart
+++ b/lib/presentation/providers/camera_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:camera/camera.dart';
+import '../../data/datasources/camera_data_source.dart';
+import '../../domain/repositories/camera_repository.dart';
+
+/// 利用可能なカメラのリストを提供するプロバイダー
+final availableCamerasProvider = FutureProvider<List<CameraDescription>>((ref) async {
+  return await availableCameras();
+});
+
+/// カメラデータソースプロバイダー
+final cameraDataSourceProvider = Provider.family<CameraDataSource, CameraDescription>((ref, camera) {
+  return CameraDataSourceImpl(camera);
+});
+
+/// カメラリポジトリプロバイダー
+/// CameraRepository型のインスタンスを提供する
+/// 実際のカメラリポジトリの実装はコンストラクタインジェクションで提供される
+final cameraRepositoryProvider = Provider<CameraRepository>((ref) {
+  throw UnimplementedError('cameraRepositoryProvider has not been initialized');
+});
+
+/// カメラコントローラープロバイダー
+/// カメラのプレビューと写真撮影に使用するCameraControllerを提供する
+final cameraControllerProvider = FutureProvider.autoDispose<CameraController>((ref) async {
+  // 利用可能なカメラを取得
+  final cameras = await ref.watch(availableCamerasProvider.future);
+  
+  // カメラが存在しない場合はエラーをスロー
+  if (cameras.isEmpty) {
+    throw Exception('No cameras available');
+  }
+  
+  // デフォルトで最初のカメラ（通常は背面カメラ）を使用
+  final camera = cameras.first;
+  
+  // カメラコントローラーを初期化
+  final controller = CameraController(
+    camera,
+    ResolutionPreset.high,
+    enableAudio: false,
+    imageFormatGroup: ImageFormatGroup.jpeg,
+  );
+  
+  // コントローラーを初期化
+  await controller.initialize();
+  
+  // プロバイダーが破棄されたときに確実にリソースを解放
+  ref.onDispose(() {
+    controller.dispose();
+  });
+  
+  return controller;
+});
+
+/// 選択中のカメラモード
+enum CameraMode {
+  normal,   // 通常撮影モード
+  overlay,  // オーバーレイ撮影モード
+}
+
+/// 現在のカメラモードを管理するプロバイダー
+final cameraModeProvider = StateProvider<CameraMode>((ref) {
+  return CameraMode.normal; // デフォルトは通常モード
+});

--- a/lib/presentation/providers/index.dart
+++ b/lib/presentation/providers/index.dart
@@ -1,0 +1,8 @@
+// プロバイダーのエクスポートファイル
+// このファイルをインポートすることで、すべてのプロバイダーを一度にインポートできる
+
+export 'camera_provider.dart';
+export 'gallery_provider.dart';
+export 'navigation_provider.dart';
+export 'overlay_provider.dart';
+export 'transparent_png_provider.dart';

--- a/lib/presentation/providers/overlay_provider.dart
+++ b/lib/presentation/providers/overlay_provider.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entities/overlay_image.dart';
+import '../../domain/repositories/overlay_repository.dart';
+
+/// オーバーレイリポジトリのプロバイダー
+/// 実際の実装はmain.dartなどで依存性注入される
+final overlayRepositoryProvider = Provider<OverlayRepository>((ref) {
+  throw UnimplementedError('overlayRepositoryProvider has not been initialized');
+});
+
+/// オーバーレイ画像の状態を管理するNotifier
+class OverlayManagerNotifier extends StateNotifier<List<OverlayImage>> {
+  OverlayManagerNotifier() : super([]);
+
+  /// 新しいオーバーレイ画像を追加
+  void addOverlay(OverlayImage overlay) {
+    if (state.length < 10) { // 最大10個までに制限
+      state = [...state, overlay];
+    }
+  }
+
+  /// 指定されたIDのオーバーレイ画像を削除
+  void removeOverlay(String id) {
+    state = state.where((overlay) => overlay.id != id).toList();
+  }
+
+  /// オーバーレイ画像の位置、サイズ、角度を更新
+  void updateOverlay(String id, {double? x, double? y, double? scale, double? rotation}) {
+    state = state.map((overlay) {
+      if (overlay.id == id) {
+        return overlay.copyWith(
+          x: x,
+          y: y,
+          scale: scale,
+          rotation: rotation,
+        );
+      }
+      return overlay;
+    }).toList();
+  }
+
+  /// 全てのオーバーレイをクリア
+  void clearOverlays() {
+    state = [];
+  }
+  
+  /// 指定されたインデックスのオーバーレイを選択状態にする
+  void selectOverlay(String id) {
+    state = state.map((overlay) {
+      if (overlay.id == id) {
+        return overlay.copyWith(isSelected: true);
+      } else {
+        // 他のオーバーレイの選択状態を解除
+        return overlay.copyWith(isSelected: false);
+      }
+    }).toList();
+  }
+  
+  /// 全てのオーバーレイの選択状態を解除
+  void clearSelection() {
+    state = state.map((overlay) => overlay.copyWith(isSelected: false)).toList();
+  }
+}
+
+/// オーバーレイ管理プロバイダー
+/// オーバーレイ画像のリストとその操作を提供
+final overlayManagerProvider = StateNotifierProvider<OverlayManagerNotifier, List<OverlayImage>>((ref) {
+  return OverlayManagerNotifier();
+});
+
+/// 現在選択中のオーバーレイ画像を提供するプロバイダー
+final selectedOverlayProvider = Provider<OverlayImage?>((ref) {
+  final overlays = ref.watch(overlayManagerProvider);
+  return overlays.firstWhere((overlay) => overlay.isSelected, orElse: () => null);
+});
+
+/// オーバーレイの表示状態を管理するプロバイダー
+final overlayVisibilityProvider = StateProvider<bool>((ref) => true);

--- a/lib/presentation/providers/transparent_png_provider.dart
+++ b/lib/presentation/providers/transparent_png_provider.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import '../../domain/repositories/transparent_png_repository.dart';
+import '../../data/repositories/image_processor.dart';
+
+/// 透過PNG生成に使用する画像のステータス
+enum TransparentPngImageStatus {
+  notSelected,    // 画像未選択
+  firstSelected,  // 1枚目選択済み
+  secondSelected, // 2枚目選択済み
+  processing,     // 処理中
+  completed,      // 処理完了
+  error,          // エラー発生
+}
+
+/// 透過PNG生成状態を管理するNotifier
+class TransparentPngNotifier extends StateNotifier<TransparentPngImageStatus> {
+  TransparentPngNotifier() : super(TransparentPngImageStatus.notSelected);
+  
+  File? _firstImage;
+  File? _secondImage;
+  Uint8List? _resultPngData;
+  String? _errorMessage;
+  
+  // ゲッター
+  File? get firstImage => _firstImage;
+  File? get secondImage => _secondImage;
+  Uint8List? get resultPngData => _resultPngData;
+  String? get errorMessage => _errorMessage;
+  
+  /// 1枚目の画像を選択
+  Future<void> selectFirstImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+    
+    if (pickedFile != null) {
+      _firstImage = File(pickedFile.path);
+      state = TransparentPngImageStatus.firstSelected;
+    }
+  }
+  
+  /// 2枚目の画像を選択
+  Future<void> selectSecondImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+    
+    if (pickedFile != null) {
+      _secondImage = File(pickedFile.path);
+      state = TransparentPngImageStatus.secondSelected;
+    }
+  }
+  
+  /// 透過PNG生成処理を実行
+  Future<void> createTransparentPng(ImageProcessor imageProcessor) async {
+    if (_firstImage == null || _secondImage == null) {
+      _errorMessage = "2枚の画像が必要です";
+      state = TransparentPngImageStatus.error;
+      return;
+    }
+    
+    state = TransparentPngImageStatus.processing;
+    
+    try {
+      _resultPngData = await imageProcessor.createTransparentPng(
+        _firstImage!,
+        _secondImage!,
+      );
+      state = TransparentPngImageStatus.completed;
+    } catch (e) {
+      _errorMessage = e.toString();
+      state = TransparentPngImageStatus.error;
+    }
+  }
+  
+  /// 状態をリセット
+  void reset() {
+    _firstImage = null;
+    _secondImage = null;
+    _resultPngData = null;
+    _errorMessage = null;
+    state = TransparentPngImageStatus.notSelected;
+  }
+}
+
+/// 透過PNG生成用リポジトリプロバイダー
+final transparentPngRepositoryProvider = Provider<TransparentPngRepository>((ref) {
+  throw UnimplementedError('transparentPngRepositoryProvider has not been initialized');
+});
+
+/// 画像処理プロバイダー
+final imageProcessorProvider = Provider<ImageProcessor>((ref) {
+  return ImageProcessor();
+});
+
+/// 透過PNG生成プロバイダー
+final transparentPngProvider = StateNotifierProvider<TransparentPngNotifier, TransparentPngImageStatus>((ref) {
+  return TransparentPngNotifier();
+});
+
+/// 処理結果の透過PNGを提供するプロバイダー
+final resultTransparentPngProvider = Provider<Uint8List?>((ref) {
+  final status = ref.watch(transparentPngProvider);
+  if (status == TransparentPngImageStatus.completed) {
+    return ref.watch(transparentPngProvider.notifier).resultPngData;
+  }
+  return null;
+});
+
+/// エラーメッセージを提供するプロバイダー
+final transparentPngErrorProvider = Provider<String?>((ref) {
+  final status = ref.watch(transparentPngProvider);
+  if (status == TransparentPngImageStatus.error) {
+    return ref.watch(transparentPngProvider.notifier).errorMessage;
+  }
+  return null;
+});
+
+/// 選択された2枚の画像を提供するプロバイダー
+final selectedImagesProvider = Provider<(File?, File?)>((ref) {
+  final notifier = ref.watch(transparentPngProvider.notifier);
+  return (notifier.firstImage, notifier.secondImage);
+});


### PR DESCRIPTION
## 概要
設計ドキュメントに従って、不足していたプロバイダーを実装しました。

## 追加したファイル
- camera_provider.dart - カメラ操作に関するプロバイダー
- overlay_provider.dart - オーバーレイ画像管理に関するプロバイダー
- transparent_png_provider.dart - 透過PNG生成に関するプロバイダー
- index.dart - すべてのプロバイダーをインポートするためのインデックスファイル

## 実装の詳細
- カメラプロバイダー: カメラの初期化、操作、モード管理のためのプロバイダー
- オーバーレイプロバイダー: オーバーレイ画像の追加、削除、更新、選択状態管理のためのプロバイダー
- 透過PNGプロバイダー: 透過PNG生成のためのプロバイダー（画像選択、処理、結果管理）

## 留意点
- すべてのリポジトリプロバイダーは依存性注入が必要なため、実際の初期化はmain.dartなどで行う必要があります
- 既存のエンティティを使用して実装しているため、コードの修正は行っていません
- プロバイダーは設計ドキュメントの機能を実現するために必要な最小限の機能を提供します